### PR TITLE
Fixed bug in AzureLock that caused timeout when Azure returned 409

### DIFF
--- a/AzureDirectory/AzureLock.cs
+++ b/AzureDirectory/AzureLock.cs
@@ -151,7 +151,7 @@ namespace Lucene.Net.Store.Azure
 
         private bool _handleWebException(ICloudBlob blob, StorageException err)
         {
-            if (err.RequestInformation.HttpStatusCode == 404)
+            if (err.RequestInformation.HttpStatusCode == 404 || err.RequestInformation.HttpStatusCode == 409)
             {
                 _azureDirectory.CreateContainer();
                 using (var stream = new MemoryStream())


### PR DESCRIPTION
Fixed bug in AzureLock that caused timeout when Azure returned 409. Previously it only handled 404, however 409 is sometimes thrown by Azure. The code 409 means that the file is corrupted and must be removed, so this change allows the lock file to be overwritten.
