### PR TITLE
Check before reading blob metadata

### DIFF
--- a/AzureDirectory/AzureDirectory.cs
+++ b/AzureDirectory/AzureDirectory.cs
@@ -180,8 +180,11 @@ namespace Lucene.Net.Store.Azure
             blob.FetchAttributes();
 
             // index files may be compressed so the actual length is stored in metatdata
+            string blobLegthMetadata;
+            bool hasMetadataValue = blob.Metadata.TryGetValue("CachedLength", out blobLegthMetadata);
+
             long blobLength;
-            if (long.TryParse(blob.Metadata["CachedLength"], out blobLength))
+            if (hasMetadataValue && long.TryParse(blobLegthMetadata, out blobLength))
                 return blobLength;
             else
                 return blob.Properties.Length; // fall back to actual blob size

--- a/AzureDirectory/AzureIndexInput.cs
+++ b/AzureDirectory/AzureIndexInput.cs
@@ -47,13 +47,18 @@ namespace Lucene.Net.Store.Azure
                 else
                 {
                     long cachedLength = CacheDirectory.FileLength(fileName);
+                    string blobLengthMetadata;
+                    bool hasMetadataValue = blob.Metadata.TryGetValue("CachedLength", out blobLengthMetadata); 
                     long blobLength = blob.Properties.Length;
-                    long.TryParse(blob.Metadata["CachedLength"], out blobLength);
+                    if (hasMetadataValue) long.TryParse(blobLengthMetadata, out blobLength);
 
+                    string blobLastModifiedMetadata;
                     long longLastModified = 0;
                     DateTime blobLastModifiedUTC = blob.Properties.LastModified.Value.UtcDateTime;
-                    if (long.TryParse(blob.Metadata["CachedLastModified"], out longLastModified))
-                        blobLastModifiedUTC = new DateTime(longLastModified).ToUniversalTime();
+                    if (blob.Metadata.TryGetValue("CachedLastModified", out blobLastModifiedMetadata)) {
+                        if (long.TryParse(blobLastModifiedMetadata, out longLastModified))
+                            blobLastModifiedUTC = new DateTime(longLastModified).ToUniversalTime();
+                    }
                     
                     if (cachedLength != blobLength)
                         fFileNeeded = true;


### PR DESCRIPTION
Prevent error when metadata is missing by trying to read it, and not
assuming it is available.
