### PR TITLE
Switched drive from hardcoded C

### DIFF
--- a/AzureDirectory/AzureDirectory.cs
+++ b/AzureDirectory/AzureDirectory.cs
@@ -85,7 +85,7 @@ namespace Lucene.Net.Store.Azure
             }
             else
             {
-                var cachePath = Path.Combine("c:\\", "AzureDirectory");
+                var cachePath = Path.Combine(Path.GetPathRoot(Environment.SystemDirectory), "AzureDirectory");
                 var azureDir = new DirectoryInfo(cachePath);
                 if (!azureDir.Exists)
                     azureDir.Create();


### PR DESCRIPTION
Ironically, the commit "switched temp to C drive, and there's more
space" broke AzureDirectory in Azure cloud service deployments.
